### PR TITLE
Bump Jenkins core version from 60.3 to 2.89.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.89.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
     <name>Alauda DevOps Credentials Provider Plugin</name>


### PR DESCRIPTION
We should use an LTS version instead of a weekly one